### PR TITLE
Allow starting suricata with options set from envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Please refer to the README.md in the master branch for up to date
 usage instructions.
 
 https://github.com/jasonish/docker-suricata/blob/master/README.md
+
+Added support for setting suricata startup options via setting environment
+variable SURICATA_OPTIONS to better support automation via Ansible, Kubernetes
+etc.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,8 +62,8 @@ else
     args=(--user suricata --group suricata)
 fi
 
-if [[-n "$SURICATA_OPTIONS"]]; then
-    exec /usr/bin/suricata "${args[@]}" $@ $SURICATA_OPTIONS
+if [[ "${SURICATA_OPTIONS}" ]]; then
+    exec /usr/bin/suricata "${args[@]}" $@ ${SURICATA_OPTIONS}
 else
     exec /usr/bin/suricata "${args[@]}" $@
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,4 +62,7 @@ else
     args=(--user suricata --group suricata)
 fi
 
-exec /usr/bin/suricata "${args[@]}" $@
+if [-n "$SURICATA_OPTIONS"]
+    exec /usr/bin/suricata "${args[@]}" $@ $SURICATA_OPTIONS
+else
+    exec /usr/bin/suricata "${args[@]}" $@

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,7 +62,7 @@ else
     args=(--user suricata --group suricata)
 fi
 
-if [[-n "$SURICATA_OPTIONS"]]
+if [[-n "$SURICATA_OPTIONS"]]; then
     exec /usr/bin/suricata "${args[@]}" $@ $SURICATA_OPTIONS
 else
     exec /usr/bin/suricata "${args[@]}" $@

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -66,3 +66,4 @@ if [-n "$SURICATA_OPTIONS"]
     exec /usr/bin/suricata "${args[@]}" $@ $SURICATA_OPTIONS
 else
     exec /usr/bin/suricata "${args[@]}" $@
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,7 +62,7 @@ else
     args=(--user suricata --group suricata)
 fi
 
-if [-n "$SURICATA_OPTIONS"]
+if [[-n "$SURICATA_OPTIONS"]]
     exec /usr/bin/suricata "${args[@]}" $@ $SURICATA_OPTIONS
 else
     exec /usr/bin/suricata "${args[@]}" $@


### PR DESCRIPTION
Check if suricata env var is set and run with option if so. This is beneficial for automation through ansible, kubernetes etc since the running images with nith options is not directly supported.