### PR TITLE
Start crond to be able to execute logrotate automatically

### DIFF
--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -70,7 +70,9 @@ set -m
 /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@ &
 
 # run helper processes
-crond
+if [[ "$ENABLE_CRON" == "yes" ]]; then
+    crond
+fi
 
 # bring the primary process back into the foreground
 fg %1

--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -63,4 +63,14 @@ else
     ARGS="${ARGS} --user suricata --group suricata"
 fi
 
-exec /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@
+# turn on bash's job control
+set -m
+
+# run primary process
+/usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@ &
+
+# run helper processes
+crond
+
+# bring the primary process back into the foreground
+fg %1

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ to test, logrotate can run in a force and verbose mode:
 docker exec CONTAINER_ID logrotate -vf /etc/logrotate.d/suricata
 ```
 
+to run logrotate automatically create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
+
+```
+#!/bin/bash
+
+logrotate /etc/logrotate.d/suricata
+```
+
 ## Volumes
 
 The Suricata container exposes the following volumes:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ to test, logrotate can run in a force and verbose mode:
 docker exec CONTAINER_ID logrotate -vf /etc/logrotate.d/suricata
 ```
 
-to run logrotate automatically create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
+to run logrotate automatically set `ENABLE_CRON=yes` enviroment variable and create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
 
 ```
 #!/bin/bash


### PR DESCRIPTION
Changes in entrypoint script follows: https://docs.docker.com/engine/containers/multi-service_container/#use-bash-job-controls