### PR TITLE
cron/v2

### DIFF
--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -70,7 +70,9 @@ set -m
 /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@ &
 
 # run helper processes
-crond
+if [[ "$ENABLE_CRON" == "yes" ]]; then
+    crond
+fi
 
 # bring the primary process back into the foreground
 fg %1

--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -63,4 +63,14 @@ else
     ARGS="${ARGS} --user suricata --group suricata"
 fi
 
-exec /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@
+# turn on bash's job control
+set -m
+
+# run primary process
+/usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@ &
+
+# run helper processes
+crond
+
+# bring the primary process back into the foreground
+fg %1

--- a/7.0/docker-entrypoint.sh
+++ b/7.0/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -e
 
@@ -63,16 +63,10 @@ else
     ARGS="${ARGS} --user suricata --group suricata"
 fi
 
-# turn on bash's job control
-set -m
-
-# run primary process
-/usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@ &
-
 # run helper processes
 if [[ "$ENABLE_CRON" == "yes" ]]; then
     crond
 fi
 
-# bring the primary process back into the foreground
-fg %1
+# run primary process
+exec /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ to test, logrotate can run in a force and verbose mode:
 docker exec CONTAINER_ID logrotate -vf /etc/logrotate.d/suricata
 ```
 
+to run logrotate automatically create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
+
+```
+#!/bin/bash
+
+logrotate /etc/logrotate.d/suricata
+```
+
 ## Volumes
 
 The Suricata container exposes the following volumes:

--- a/README.md
+++ b/README.md
@@ -108,13 +108,19 @@ to test, logrotate can run in a force and verbose mode:
 docker exec CONTAINER_ID logrotate -vf /etc/logrotate.d/suricata
 ```
 
-to run logrotate automatically set `ENABLE_CRON=yes` enviroment variable and create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
+to run logrotate automatically set the `ENABLE_CRON=yes` environment
+variable and create `suricata` bash script, with executable
+permissions, in one of `/etc/cron.*` directories
+(e.g. `/etc/cron.hourly/suricata`):
 
 ```
-#!/bin/bash
+#! /bin/bash
 
 logrotate /etc/logrotate.d/suricata
 ```
+
+This script could be created in a `Dockerfile` using this one as a
+base, or bind mounted in as a volume.
 
 ## Volumes
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ to test, logrotate can run in a force and verbose mode:
 docker exec CONTAINER_ID logrotate -vf /etc/logrotate.d/suricata
 ```
 
-to run logrotate automatically create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
+to run logrotate automatically set `ENABLE_CRON=yes` enviroment variable and create `suricata` bash script, with executable persmissins, in one of `/etc/cron.*` directories (e.g. `/etc/cron.hourly/suricata`):
 
 ```
 #!/bin/bash

--- a/master/docker-entrypoint.sh
+++ b/master/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 set -e
 
@@ -63,4 +63,10 @@ else
     ARGS="${ARGS} --user suricata --group suricata"
 fi
 
+# run helper processes
+if [[ "$ENABLE_CRON" == "yes" ]]; then
+    crond
+fi
+
+# run primary process
 exec /usr/bin/suricata ${ARGS} ${SURICATA_OPTIONS} $@


### PR DESCRIPTION
- **Start crond to be able to execute logrotate automatically**
  Signed-off-by: Remigiusz Kollataj <remigiusz.kollataj@dreamlab.net>
  

- **Add ENABLE_CRON environment variable handling**
  Signed-off-by: Remigiusz Kollataj <remigiusz.kollataj@dreamlab.net>
  

- **cron: execute cron before suricata so we can exec suricata**
  This keeps Suricata the primary process.
  