### PR TITLE
Rules profiling

### DIFF
--- a/7.0/Dockerfile.amd64
+++ b/7.0/Dockerfile.amd64
@@ -78,6 +78,7 @@ RUN ./configure \
         --enable-geoip \
         --enable-ebpf \
 	--enable-dpdk \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2

--- a/7.0/Dockerfile.arm64
+++ b/7.0/Dockerfile.arm64
@@ -80,6 +80,7 @@ RUN ./configure \
         --enable-geoip \
         --enable-ebpf \
 	--enable-dpdk \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2

--- a/8.0/Dockerfile.amd64
+++ b/8.0/Dockerfile.amd64
@@ -76,6 +76,7 @@ RUN ./configure \
         --enable-geoip \
         --enable-ebpf \
 	--enable-dpdk \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2

--- a/8.0/Dockerfile.arm64
+++ b/8.0/Dockerfile.arm64
@@ -78,6 +78,7 @@ RUN ./configure \
         --enable-geoip \
         --enable-ebpf \
 	--enable-dpdk \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2

--- a/main/Dockerfile.amd64
+++ b/main/Dockerfile.amd64
@@ -76,6 +76,7 @@ RUN ./configure \
         --enable-geoip \
         --enable-ebpf \
 	--enable-dpdk \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2

--- a/main/Dockerfile.arm64
+++ b/main/Dockerfile.arm64
@@ -74,6 +74,7 @@ RUN ./configure \
         --enable-hiredis \
         --enable-geoip \
         --enable-ebpf \
+        --enable-profiling-rules \
         ${CONFIGURE_ARGS}
 
 ARG CORES=2


### PR DESCRIPTION
Add rules profiling build option to regular build. It is deactivated by default and need to be activated via --set commands.